### PR TITLE
Back button on the screenshot-dialog menu, takes us back to interactive dialog

### DIFF
--- a/src/screenshot-application.c
+++ b/src/screenshot-application.c
@@ -396,6 +396,12 @@ screenshot_save_to_file (ScreenshotApplication *self)
 static void
 screenshot_save_to_clipboard (ScreenshotApplication *self)
 {
+    screenshot_show_interactive_dialog(self);
+}
+
+    static void
+screenshot_save_to_clipboard (ScreenshotApplication *self)
+{
   GtkClipboard *clipboard;
 
   clipboard = gtk_clipboard_get_for_display (gdk_display_get_default (),
@@ -418,6 +424,8 @@ screenshot_dialog_response_cb (ScreenshotResponse response,
     case SCREENSHOT_RESPONSE_COPY:
       screenshot_save_to_clipboard (self);
       break;
+    case SCREENSHOT_RESPONSE_BACK:
+      screenshot_back(self);
     default:
       g_assert_not_reached ();
       break;

--- a/src/screenshot-application.c
+++ b/src/screenshot-application.c
@@ -45,8 +45,11 @@
 
 G_DEFINE_TYPE (ScreenshotApplication, screenshot_application, GTK_TYPE_APPLICATION);
 
+static void screenshot_application_startup (GApplication *app);
+static void screenshot_back (ScreenshotApplication *self);
 static void screenshot_save_to_file (ScreenshotApplication *self);
 static void screenshot_show_interactive_dialog (ScreenshotApplication *self);
+static void screenshot_start (ScreenshotApplication *self);
 
 struct _ScreenshotApplicationPriv {
   gchar *icc_profile_base64;
@@ -393,13 +396,18 @@ screenshot_save_to_file (ScreenshotApplication *self)
   g_object_unref (target_file);
 }
 
+
 static void
-screenshot_save_to_clipboard (ScreenshotApplication *self)
+screenshot_back (ScreenshotApplication *self)
 {
-    screenshot_show_interactive_dialog(self);
+  ScreenshotDialog *dialog = self->priv->dialog;
+  save_folder_to_settings (self);
+  gtk_widget_destroy (dialog->dialog);
+  g_free (dialog);
+  screenshot_show_interactive_dialog (self);
 }
 
-    static void
+static void
 screenshot_save_to_clipboard (ScreenshotApplication *self)
 {
   GtkClipboard *clipboard;
@@ -426,6 +434,7 @@ screenshot_dialog_response_cb (ScreenshotResponse response,
       break;
     case SCREENSHOT_RESPONSE_BACK:
       screenshot_back(self);
+      break;
     default:
       g_assert_not_reached ();
       break;

--- a/src/screenshot-dialog.c
+++ b/src/screenshot-dialog.c
@@ -142,8 +142,13 @@ button_clicked (GtkWidget *button, ScreenshotDialog *dialog)
 {
   ScreenshotResponse res;
 
-  res = (button == dialog->save_button) ? SCREENSHOT_RESPONSE_SAVE
-                                        : SCREENSHOT_RESPONSE_COPY;
+  if (button == dialog->save_button) 
+      res = SCREENSHOT_RESPONSE_SAVE;
+  else if (button == dialog->copy_button)
+      res = SCREENSHOT_RESPONSE_COPY;
+  else
+      res = SCREENSHOT_RESPONSE_BACK;
+      
 
   dialog->callback (res, dialog->user_data);
 }
@@ -240,6 +245,9 @@ screenshot_dialog_new (GdkPixbuf              *screenshot,
   g_signal_connect (dialog->save_button, "clicked", G_CALLBACK (button_clicked), dialog);
   dialog->copy_button = GTK_WIDGET (gtk_builder_get_object (ui, "copy_button"));
   g_signal_connect (dialog->copy_button, "clicked", G_CALLBACK (button_clicked), dialog);
+  
+  dialog->back_button = GTK_WIDGET (gtk_builder_get_object (ui, "back_button"));
+  g_signal_connect (dialog->back_button, "clicked", G_CALLBACK (button_clicked), dialog);
 
   setup_drawing_area (dialog, ui);
 

--- a/src/screenshot-dialog.h
+++ b/src/screenshot-dialog.h
@@ -25,7 +25,8 @@
 typedef enum {
   SCREENSHOT_RESPONSE_SAVE,
   SCREENSHOT_RESPONSE_COPY,
-  SCREENSHOT_RESPOSE_BACK
+  SCREENSHOT_RESPONSE_BACK
+
 } ScreenshotResponse;
 
 typedef void (*SaveScreenshotCallback) (ScreenshotResponse response, gpointer *user_data);

--- a/src/screenshot-dialog.h
+++ b/src/screenshot-dialog.h
@@ -24,7 +24,8 @@
 
 typedef enum {
   SCREENSHOT_RESPONSE_SAVE,
-  SCREENSHOT_RESPONSE_COPY
+  SCREENSHOT_RESPONSE_COPY,
+  SCREENSHOT_RESPOSE_BACK
 } ScreenshotResponse;
 
 typedef void (*SaveScreenshotCallback) (ScreenshotResponse response, gpointer *user_data);
@@ -38,6 +39,7 @@ typedef struct {
   GtkWidget *filename_entry;
   GtkWidget *save_button;
   GtkWidget *copy_button;
+  GtkWidget *back_button;
 
   gint drag_x;
   gint drag_y;

--- a/src/screenshot-dialog.ui
+++ b/src/screenshot-dialog.ui
@@ -25,6 +25,18 @@
           </packing>
         </child>
         <child>
+          <object class="GtkButton" id="back_button">
+            <property name="label" translatable="yes">_Back</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="use_underline">True</property>
+          </object>
+          <packing>
+            <property name="pack-type">start</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkButton" id="save_button">
             <property name="label" translatable="yes">_Save</property>
             <property name="visible">True</property>

--- a/src/screenshot-interactive-dialog.c
+++ b/src/screenshot-interactive-dialog.c
@@ -435,6 +435,10 @@ capture_button_clicked_cb (GtkButton *button, CaptureData *data)
 GtkWidget *
 screenshot_interactive_dialog_new (CaptureClickedCallback f, gpointer user_data)
 {
+
+  FILE *log;
+  log = fopen("/tmp/gslog","a");
+
   GtkWidget *dialog;
   GtkWidget *main_vbox;
   GtkWidget *header_bar;
@@ -510,7 +514,10 @@ screenshot_interactive_dialog_new (CaptureClickedCallback f, gpointer user_data)
 
   g_object_unref (size_group);
 
+
   gtk_widget_show_all (dialog);
 
+  fprintf(log,"made interactive dialog\n");
+  fclose(log);
   return dialog;
 }


### PR DESCRIPTION
If I mess up a screenshot I just want to hit back to take it again without reopening.