### PR TITLE
make flash, sound and saving in recent files configureable

### DIFF
--- a/src/screenshot-config.c
+++ b/src/screenshot-config.c
@@ -102,6 +102,9 @@ screenshot_save_config (void)
 
 gboolean
 screenshot_config_parse_command_line (gboolean clipboard_arg,
+                                      gboolean noflash_arg,
+			              gboolean nosound_arg,
+				      gboolean norecent_arg,
                                       gboolean window_arg,
                                       gboolean area_arg,
                                       gboolean include_border_arg,
@@ -168,6 +171,10 @@ screenshot_config_parse_command_line (gboolean clipboard_arg,
 
   screenshot_config->take_window_shot = window_arg;
   screenshot_config->take_area_shot = area_arg;
+
+  screenshot_config->noflash = noflash_arg;
+  screenshot_config->nosound = nosound_arg;
+  screenshot_config->norecent = norecent_arg;
 
   return TRUE;
 }

--- a/src/screenshot-config.h
+++ b/src/screenshot-config.h
@@ -33,10 +33,12 @@ typedef struct {
   GFile *file;
 
   gboolean copy_to_clipboard;
+  gboolean noflash;
+  gboolean nosound;
+  gboolean norecent;
 
   gboolean take_window_shot;
   gboolean take_area_shot;
-
   gboolean include_pointer;
   gboolean include_icc_profile;
 
@@ -53,6 +55,9 @@ extern ScreenshotConfig *screenshot_config;
 void        screenshot_load_config                (void);
 void        screenshot_save_config                (void);
 gboolean    screenshot_config_parse_command_line  (gboolean clipboard_arg,
+		                                   gboolean noflash_arg,
+						   gboolean nosound_arg,
+						   gboolean norecent_arg,
                                                    gboolean window_arg,
                                                    gboolean area_arg,
                                                    gboolean include_border_arg,

--- a/src/screenshot-utils.c
+++ b/src/screenshot-utils.c
@@ -580,8 +580,10 @@ screenshot_fallback_get_pixbuf (GdkRectangle *rectangle)
         }
     }
 
-  screenshot_fallback_fire_flash (window, rectangle);
-
+  if (!screenshot_config->noflash) 
+    {
+      screenshot_fallback_fire_flash (window, rectangle);
+    }
   return screenshot;
 }
 
@@ -607,7 +609,7 @@ screenshot_shell_get_pixbuf (GdkRectangle *rectangle)
       method_params = g_variant_new ("(bbbs)",
                                      screenshot_config->include_border,
                                      screenshot_config->include_pointer,
-                                     TRUE, /* flash */
+                                     !screenshot_config->noflash, /* flash */
                                      filename);
     }
   else if (rectangle != NULL)
@@ -616,7 +618,7 @@ screenshot_shell_get_pixbuf (GdkRectangle *rectangle)
       method_params = g_variant_new ("(iiiibs)",
                                      rectangle->x, rectangle->y,
                                      rectangle->width, rectangle->height,
-                                     TRUE, /* flash */
+                                     !screenshot_config->noflash, /* flash */
                                      filename);
     }
   else
@@ -624,7 +626,7 @@ screenshot_shell_get_pixbuf (GdkRectangle *rectangle)
       method_name = "Screenshot";
       method_params = g_variant_new ("(bbs)",
                                      screenshot_config->include_pointer,
-                                     TRUE, /* flash */
+                                     !screenshot_config->noflash, /* flash */
                                      filename);
     }
 


### PR DESCRIPTION
When invoking gnome-screenshot via command line in a script, e.g., to take many screenshots for a tutorial, the constant flashing / shutter sound gets annoying. Previously there were many alternatives for this use-case, e.g., scrot. But since these command-line screenshot tools do not deal with Wayland atm, I opted for adding switches to gnome-screenshot.